### PR TITLE
Fix for the crash due to missing environment Keyboard Observer object

### DIFF
--- a/QBChat-MVVM/QBChat-MVVM/Common/SceneDelegate.swift
+++ b/QBChat-MVVM/QBChat-MVVM/Common/SceneDelegate.swift
@@ -24,6 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let viewModel = AnyViewModel(ChatListViewModel(chatService: chatService))
         let contentView = ChatListView()
             .environmentObject(viewModel)
+            .environmentObject(KeyboardObserver.shared)
 
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {

--- a/QBChat-MVVM/QBChat-MVVM/View/ChatList/ChatListView.swift
+++ b/QBChat-MVVM/QBChat-MVVM/View/ChatList/ChatListView.swift
@@ -26,8 +26,10 @@ struct ChatListView: View {
     var body: some View {
         NavigationView {
             List(viewModel.chats) { viewModel in
-                NavigationLink(destination: ChatDetailView().environmentObject(viewModel)) {
-                    ChatCell(chat: viewModel.state.chat)
+                NavigationLink(destination: ChatDetailView()
+                    .environmentObject(viewModel)
+                    .environmentObject(KeyboardObserver.shared)) {
+                        ChatCell(chat: viewModel.state.chat)
                 }
             }
             .navigationBarTitle("Chats")

--- a/QBChat-MVVM/QBChat-MVVM/View/ChatList/ChatListView.swift
+++ b/QBChat-MVVM/QBChat-MVVM/View/ChatList/ChatListView.swift
@@ -26,10 +26,8 @@ struct ChatListView: View {
     var body: some View {
         NavigationView {
             List(viewModel.chats) { viewModel in
-                NavigationLink(destination: ChatDetailView()
-                    .environmentObject(viewModel)
-                    .environmentObject(KeyboardObserver.shared)) {
-                        ChatCell(chat: viewModel.state.chat)
+                NavigationLink(destination: ChatDetailView().environmentObject(viewModel)) {
+                    ChatCell(chat: viewModel.state.chat)
                 }
             }
             .navigationBarTitle("Chats")


### PR DESCRIPTION
Keyboard Observer environment object is provided for the ChatDetailView - the only view which need it. Another solution is to provide it to the root view in the SceneDelegate.